### PR TITLE
Feat/file writer file output

### DIFF
--- a/lib/file_writer.rb
+++ b/lib/file_writer.rb
@@ -1,0 +1,7 @@
+
+
+class FileWriter
+
+
+
+end

--- a/lib/file_writer.rb
+++ b/lib/file_writer.rb
@@ -2,6 +2,13 @@
 
 class FileWriter
 
+  attr_reader :output_file_name
 
+  def initialize
+    @output_file_name = ARGV[1]
+  end
 
+  def write_file
+    File.new(@output_file_name, "w")
+  end
 end

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -1,11 +1,15 @@
 require "./lib/file_reader"
+require './lib/file_writer'
 
 class NightWriter
 
-  attr_reader :file_reader
+  attr_reader :file_reader,
+              :file_writer
 
   def initialize
     @file_reader = FileReader.new.read
+    @file_writer = FileWriter.new
+    @file_writer.write_file
   end
 
   def confirmation_display

--- a/spec/file_writer_spec.rb
+++ b/spec/file_writer_spec.rb
@@ -1,0 +1,12 @@
+require './lib/file_writer'
+
+RSpec.describe FileWriter do
+
+  it "exists" do
+    file_write = FileWriter.new
+
+
+    expect(file_write).to be_a(FileWriter)
+  end
+
+end

--- a/spec/file_writer_spec.rb
+++ b/spec/file_writer_spec.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require './lib/file_writer'
 
 RSpec.describe FileWriter do
@@ -8,5 +11,26 @@ RSpec.describe FileWriter do
 
     expect(file_write).to be_a(FileWriter)
   end
+
+  it "can write a file" do
+    file_write = FileWriter.new
+    output = "output"
+    file_write.stub(:read).and_return(output)
+
+
+    expect(file_write.write_file).to eq(nil)
+  end
+
+  # it 'How to mock File.open for write with rspec 3.4' do
+  #   file_writer = FileWriter.new
+  #   buffer = StringIO.new()
+  #   file_name = "somefile.txt"
+  #   content = "the content fo the file"
+  #   allow(file_writer).to receive(:open).with(file_name,'w').and_yield( buffer )
+  #   # call the function that writes to the file
+  #   # file_write.write_file {|f| f.write(content)}
+  #   # reading the buffer and checking its content.
+  #   expect(file_write.write_file).to eq(content)
+  # end
 
 end


### PR DESCRIPTION
NightWriter can now output a file relative to a file read from FileReader. Test for #write_file method from 'file_writer_spec.rb' will fail. Ask how to test this method.
NightWriter outputs #confirmation_display statement and creates an empty output file.